### PR TITLE
[Bugfix] Characters Screen: load characters only on create and show error state only if characters list is empty

### DIFF
--- a/app/src/main/java/com/vadymmy/ricktionary/ui/base/BaseViewModel.kt
+++ b/app/src/main/java/com/vadymmy/ricktionary/ui/base/BaseViewModel.kt
@@ -18,6 +18,7 @@ abstract class BaseViewModel<STATE, INTENT, EFFECT>(
     val uiEffectFlow: SharedFlow<EFFECT> = MutableSharedFlow()
     protected val uiState get() = uiStateFlow.value
 
+    open fun onCreate() = Unit
     open fun onResume() = Unit
 
     fun onUserIntent(intent: INTENT) = reduceIntent(intent)

--- a/app/src/main/java/com/vadymmy/ricktionary/ui/characters/list/CharactersScreen.kt
+++ b/app/src/main/java/com/vadymmy/ricktionary/ui/characters/list/CharactersScreen.kt
@@ -27,8 +27,8 @@ import com.vadymmy.ricktionary.ui.theme.margin2X
 fun CharactersScreen(charactersViewModel: CharactersViewModel = hiltViewModel()) {
     val uiState by charactersViewModel.uiStateFlow.collectAsState()
 
-    LifecycleEffect(onResume = {
-        charactersViewModel.onResume()
+    LifecycleEffect(onCreate = {
+        charactersViewModel.onCreate()
     })
 
     CharactersScreenContent(
@@ -87,7 +87,7 @@ private fun CharactersScreenScaffold(
             topBar()
 
             when {
-                uiState.showLoadingError -> {
+                uiState.showLoadingError && uiState.characters.isEmpty() -> {
                     errorState()
                 }
 

--- a/app/src/main/java/com/vadymmy/ricktionary/ui/characters/list/CharactersViewModel.kt
+++ b/app/src/main/java/com/vadymmy/ricktionary/ui/characters/list/CharactersViewModel.kt
@@ -21,7 +21,7 @@ class CharactersViewModel @Inject constructor(
         observeCharactersFlow()
     }
 
-    override fun onResume() {
+    override fun onCreate() {
         fetchCharacters()
     }
 

--- a/app/src/main/java/com/vadymmy/ricktionary/ui/characters/list/composable/CharacterLoadingItem.kt
+++ b/app/src/main/java/com/vadymmy/ricktionary/ui/characters/list/composable/CharacterLoadingItem.kt
@@ -4,16 +4,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.vadymmy.ricktionary.ui.core.animation.shimmerLoading
 import com.vadymmy.ricktionary.ui.core.composable.ItemCard
 import com.vadymmy.ricktionary.ui.theme.characterItemImageSize
 
 @Composable
 fun CharacterLoadingItem() {
     ItemCard(
-        modifier = Modifier
-            .height(characterItemImageSize)
-            .shimmerLoading()
+        modifier = Modifier.height(characterItemImageSize),
+        showShimmerLoading = true
     )
 }
 

--- a/app/src/main/java/com/vadymmy/ricktionary/ui/core/composable/ItemCard.kt
+++ b/app/src/main/java/com/vadymmy/ricktionary/ui/core/composable/ItemCard.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
+import com.vadymmy.ricktionary.ui.core.animation.shimmerLoading
+import com.vadymmy.ricktionary.ui.core.modifier.modifyIf
 import com.vadymmy.ricktionary.ui.theme.AppColors
 import com.vadymmy.ricktionary.ui.theme.cardContainerShapeDefault
 import com.vadymmy.ricktionary.ui.theme.characterItemImageSize
@@ -18,6 +20,7 @@ import com.vadymmy.ricktionary.ui.theme.characterItemImageSize
 fun ItemCard(
     modifier: Modifier = Modifier,
     paddingValues: PaddingValues = PaddingValues(),
+    showShimmerLoading: Boolean = false,
     content: @Composable () -> Unit = {}
 ) {
     Box(
@@ -26,6 +29,9 @@ fun ItemCard(
             .background(color = AppColors.ItemBackground, shape = cardContainerShapeDefault)
             .clip(shape = cardContainerShapeDefault)
             .padding(paddingValues)
+            .modifyIf(showShimmerLoading) {
+                shimmerLoading()
+            }
     ) {
         content()
     }

--- a/app/src/main/java/com/vadymmy/ricktionary/ui/core/modifier/Modifiers.kt
+++ b/app/src/main/java/com/vadymmy/ricktionary/ui/core/modifier/Modifiers.kt
@@ -1,0 +1,9 @@
+package com.vadymmy.ricktionary.ui.core.modifier
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun Modifier.modifyIf(condition: Boolean, modifier: @Composable Modifier.() -> Modifier): Modifier {
+    return if (condition) this.then(modifier(Modifier)) else this
+}


### PR DESCRIPTION
# Description
This PR fixes a few issues on the Characters Screen:
- The shimmer is not showing;
- The error state is shown even after the fetch was successful but the refetch wasn't;
- The Characters Screen always showing the loading even if the items are already loaded.

To fix them, I moved the fetch to the `onCreate` so the items are initially fetched once. Also, I show the error state only if the characters list is empty and fetch wasn't successful, so if the user fetches the list but the network goes down, the list will still be shown from the cache.