### PR TITLE
[Bug] Character Screen: load items from LazyPagingItems instead of using the snapshot list to trigger APPEND properly

### DIFF
--- a/app/src/main/java/com/vadymmy/ricktionary/ui/characters/list/CharactersScreen.kt
+++ b/app/src/main/java/com/vadymmy/ricktionary/ui/characters/list/CharactersScreen.kt
@@ -52,13 +52,10 @@ private fun CharactersScreenContent(
         content = { isLoading ->
             CharactersList(
                 isLoading = isLoading,
-                characters = characters.itemSnapshotList.items,
-                onPulledToRefresh = {
-                    characters.refresh()
-                },
-                onCharacterClicked = {
-                    onUserIntent(CharactersIntent.CharacterItemClicked(it))
-                }
+                charactersCount = characters.itemCount,
+                getCharacter = { characters[it] },
+                onPulledToRefresh = { characters.refresh() },
+                onCharacterClicked = { onUserIntent(CharactersIntent.CharacterItemClicked(it)) }
             )
         },
         emptyState = {

--- a/app/src/main/java/com/vadymmy/ricktionary/ui/characters/list/composable/CharactersList.kt
+++ b/app/src/main/java/com/vadymmy/ricktionary/ui/characters/list/composable/CharactersList.kt
@@ -2,7 +2,6 @@ package com.vadymmy.ricktionary.ui.characters.list.composable
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -13,32 +12,36 @@ import com.vadymmy.ricktionary.ui.characters.common.preview.CharacterPreview
 import com.vadymmy.ricktionary.ui.theme.margin2X
 
 private const val LOADING_ITEMS_SIZE = 10
+private const val NO_CHARACTERS = 0
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CharactersList(
     isLoading: Boolean,
-    characters: List<CharacterItemUiModel>,
+    charactersCount: Int,
+    getCharacter: (index: Int) -> CharacterItemUiModel?,
     onPulledToRefresh: () -> Unit = {},
     onCharacterClicked: (CharacterItemUiModel) -> Unit = {}
 ) {
     val pullToRefreshState = rememberPullToRefreshState()
 
     PullToRefreshBox(
-        isRefreshing = isLoading && characters.isNotEmpty(),
+        isRefreshing = isLoading && charactersCount > NO_CHARACTERS,
         state = pullToRefreshState,
         onRefresh = onPulledToRefresh
     ) {
         LazyColumn(verticalArrangement = Arrangement.spacedBy(margin2X)) {
-            if (isLoading && characters.isEmpty()) {
+            if (isLoading && charactersCount == NO_CHARACTERS) {
                 items(LOADING_ITEMS_SIZE) {
                     CharacterLoadingItem()
                 }
             } else {
-                items(characters, key = { it.id }) {
+                items(charactersCount) {
+                    val item = getCharacter(it) ?: return@items
+
                     CharacterItem(
-                        item = it,
-                        onClick = { onCharacterClicked(it) }
+                        item = item,
+                        onClick = { onCharacterClicked(item) }
                     )
                 }
             }
@@ -51,7 +54,8 @@ fun CharactersList(
 private fun CharactersListLoadingPreview() {
     CharactersList(
         isLoading = true,
-        characters = emptyList()
+        charactersCount = 0,
+        getCharacter = { null }
     )
 }
 
@@ -60,7 +64,10 @@ private fun CharactersListLoadingPreview() {
 private fun CharactersListRefreshLoadingPreview() {
     CharactersList(
         isLoading = true,
-        characters = CharacterPreview.characterItems
+        charactersCount = CharacterPreview.characterItems.size,
+        getCharacter = {
+            CharacterPreview.characterItems[it]
+        }
     )
 }
 
@@ -69,6 +76,9 @@ private fun CharactersListRefreshLoadingPreview() {
 private fun CharactersListPreview() {
     CharactersList(
         isLoading = false,
-        characters = CharacterPreview.characterItems
+        charactersCount = CharacterPreview.characterItems.size,
+        getCharacter = {
+            CharacterPreview.characterItems[it]
+        }
     )
 }


### PR DESCRIPTION
# Description
In this PR I fixed an issue that the APPEND isn't triggered in the pagination. I found that the `itemSnapshotList` doesn't trigger the APPEND when the user is scrolling down. To fix this, I make the `CharactersList` use the getter from the `LazyPagingItems` which triggers the required calls.